### PR TITLE
add AD7414 temperature sensor display capability for the OLED

### DIFF
--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -606,7 +606,7 @@ i2cset -y $I2CBUS $DEVADDR $AD7414_CONF $AD7414_DEF_CONF
 }
 
 #read temperature value register 
-function read_temperature(){
+function show_temperature(){
 local raw_val=$(($(i2cget -y $I2CBUS $DEVADDR $AD7414_VAL w)))
 local lo_val=$(("$raw_val">>14))
 local hi_val=$(("$raw_val"&0xff))
@@ -616,6 +616,7 @@ if [ $(( "$hi_val" & 0x80)) -ne 0 ]; then
 fi
 set_cursor 0 2				# Set Cursor at Page (Row) 5 to the 20th Pixel (Column)
 showtext $(printf "%.2f" $(echo $code_val / 4 | bc -l) ) 			# Some Text for the Display
+sleep 1
 }
 
 #About/Thanks to.. (THEEASTEREGG) :-)

--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -25,6 +25,9 @@ oledaddr=0x${oledid}     # OLED I2C Address with "0x"
 i2cbus=2                 # i2c-2 = Bus 2
 oledfound="false"        # Pre-Set Variable with false
 
+# I2C Temperature Sensor
+showtemp="yes"
+
 # Core related
 newcore=""
 oldcore=""

--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -13,8 +13,8 @@ ONECOLOR="no"			# Set to "yes" if you want to use the new "OneColor" and "Origin
 INVERTHEADER="no"		# Set to "yes" if you want the Header of the "original" Two-Color Pictures to be inverted. Useful if you run an One-Color Display.
 
 # Temperature Sensor (AD7414) Values
-I2CBUS=2
-DEVADDR=0x4f
+AD7414_I2CBUS=2
+AD7414_DEVADDR=0x4f
 AD7414_VAL=0x00
 AD7414_CONF=0x01
 AD7414_T_HIGH=0x02
@@ -23,6 +23,8 @@ AD7414_DEF_CONF=0x40
 
 # I2C Temperature Sensor
 SHOW_TEMP="no"                 # Set to yes in order to display temperature (AD7414) on the OLED
+SHOW_TEMP_ROW=0 
+SHOW_TEMP_COL=2
 
 # Slideshow
 SLIDETIME=3.0			# Slideshow Wait-Time until the next Picture is shown.
@@ -602,19 +604,19 @@ function warp5 () {
 
 #set default configuration
 function init_temperature_default_config(){
-i2cset -y $I2CBUS $DEVADDR $AD7414_CONF $AD7414_DEF_CONF
+i2cset -y $AD7414_I2CBUS $AD7414_DEVADDR $AD7414_CONF $AD7414_DEF_CONF
 }
 
 #read temperature value register 
 function show_temperature(){
-local raw_val=$(($(i2cget -y $I2CBUS $DEVADDR $AD7414_VAL w)))
+local raw_val=$(($(i2cget -y $AD7414_I2CBUS $AD7414_DEVADDR $AD7414_VAL w)))
 local lo_val=$(("$raw_val">>14))
 local hi_val=$(("$raw_val"&0xff))
 local code_val=$(("$lo_val"|$(("$hi_val"<<2))))
 if [ $(( "$hi_val" & 0x80)) -ne 0 ]; then
 	code_val=$(($code_val - 512))
 fi
-set_cursor 0 2				# Set Cursor at Page (Row) 5 to the 20th Pixel (Column)
+set_cursor $SHOW_TEMP_ROW $SHOW_TEMP_COL				# Set Cursor at Page Row and Column
 showtext $(printf "%.2f" $(echo $code_val / 4 | bc -l) ) 			# Some Text for the Display
 sleep 1
 }

--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -12,7 +12,7 @@ SSH1106="no"			# Set to "yes" if you use a SSH1106 Display (activates different 
 ONECOLOR="no"			# Set to "yes" if you want to use the new "OneColor" and "Original" Two-Color Pictures. Set to "no" uses only the "Original" Pictures with Header.
 INVERTHEADER="no"		# Set to "yes" if you want the Header of the "original" Two-Color Pictures to be inverted. Useful if you run an One-Color Display.
 
-# Temperature Sensor Values
+# Temperature Sensor (AD7414) Values
 I2CBUS=2
 DEVADDR=0x4f
 AD7414_VAL=0x00
@@ -22,7 +22,7 @@ AD7414_T_LOW=0x03
 AD7414_DEF_CONF=0x40
 
 # I2C Temperature Sensor
-SHOW_TEMP="yes"
+SHOW_TEMP="no"                 # Set to yes in order to display temperature (AD7414) on the OLED
 
 # Slideshow
 SLIDETIME=3.0			# Slideshow Wait-Time until the next Picture is shown.

--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -601,7 +601,7 @@ function warp5 () {
 }
 
 #set default configuration
-function init_default_config(){
+function init_temperature_default_config(){
 i2cset -y $I2CBUS $DEVADDR $AD7414_CONF $AD7414_DEF_CONF
 }
 

--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -21,6 +21,9 @@ AD7414_T_HIGH=0x02
 AD7414_T_LOW=0x03
 AD7414_DEF_CONF=0x40
 
+# I2C Temperature Sensor
+SHOW_TEMP="yes"
+
 # Slideshow
 SLIDETIME=3.0			# Slideshow Wait-Time until the next Picture is shown.
 
@@ -33,9 +36,6 @@ oledid=3c                # OLED I2C Address without "0x"
 oledaddr=0x${oledid}     # OLED I2C Address with "0x"
 i2cbus=2                 # i2c-2 = Bus 2
 oledfound="false"        # Pre-Set Variable with false
-
-# I2C Temperature Sensor
-SHOW_TEMP="yes"
 
 # Core related
 newcore=""

--- a/i2c2oled-system.ini
+++ b/i2c2oled-system.ini
@@ -12,6 +12,15 @@ SSH1106="no"			# Set to "yes" if you use a SSH1106 Display (activates different 
 ONECOLOR="no"			# Set to "yes" if you want to use the new "OneColor" and "Original" Two-Color Pictures. Set to "no" uses only the "Original" Pictures with Header.
 INVERTHEADER="no"		# Set to "yes" if you want the Header of the "original" Two-Color Pictures to be inverted. Useful if you run an One-Color Display.
 
+# Temperature Sensor Values
+I2CBUS=2
+DEVADDR=0x4f
+AD7414_VAL=0x00
+AD7414_CONF=0x01
+AD7414_T_HIGH=0x02
+AD7414_T_LOW=0x03
+AD7414_DEF_CONF=0x40
+
 # Slideshow
 SLIDETIME=3.0			# Slideshow Wait-Time until the next Picture is shown.
 
@@ -26,7 +35,7 @@ i2cbus=2                 # i2c-2 = Bus 2
 oledfound="false"        # Pre-Set Variable with false
 
 # I2C Temperature Sensor
-showtemp="yes"
+SHOW_TEMP="yes"
 
 # Core related
 newcore=""
@@ -589,6 +598,24 @@ function warp5 () {
   # Deactivate Scrolling
   i2cset -y ${i2cbus} ${oledaddr} 0x00 0x2E
   sleep 0.5
+}
+
+#set default configuration
+function init_default_config(){
+i2cset -y $I2CBUS $DEVADDR $AD7414_CONF $AD7414_DEF_CONF
+}
+
+#read temperature value register 
+function read_temperature(){
+local raw_val=$(($(i2cget -y $I2CBUS $DEVADDR $AD7414_VAL w)))
+local lo_val=$(("$raw_val">>14))
+local hi_val=$(("$raw_val"&0xff))
+local code_val=$(("$lo_val"|$(("$hi_val"<<2))))
+if [ $(( "$hi_val" & 0x80)) -ne 0 ]; then
+	code_val=$(($code_val - 512))
+fi
+set_cursor 0 2				# Set Cursor at Page (Row) 5 to the 20th Pixel (Column)
+showtext $(printf "%.2f" $(echo $code_val / 4 | bc -l) ) 			# Some Text for the Display
 }
 
 #About/Thanks to.. (THEEASTEREGG) :-)

--- a/i2c2oled.sh
+++ b/i2c2oled.sh
@@ -188,15 +188,14 @@ while true; do								# main loop
       fi
       display_on
       oldcore=${newcore}										# update oldcore variable
-    fi  														# end if core check
-    current_corenamefile=${corenamefile} #store the current corename
-    while [ ${current_corenamefile} = ${corenamefile} ] #loops until change of corename occures 
-    do
-      if [ "${SHOW_TEMP}" = "yes" ]; then #show temperature 
-        read_temperature 
-      fi
-      sleep 1
-    done
+    fi  												# end if core check
+    
+    if [ "${SHOW_TEMP}" = "yes" ]; then
+      inotifywait -e modify "${corenamefile}". | read_temperature # show temperature while waiting for the core change event 
+    else
+      inotifywait -e modify "${corenamefile}"   
+    fi
+    
     #inotifywait -qq -e modify "${corenamefile}"					# wait here for next change of corename -q for quite
     #inotifywait -e modify -t 5 "${corenamefile}"				# wait here for next change of corename
 	#echo "5 secs Timeout"

--- a/i2c2oled.sh
+++ b/i2c2oled.sh
@@ -191,7 +191,7 @@ while true; do								# main loop
     fi  												# end if core check
     
     if [ "${SHOW_TEMP}" = "yes" ]; then
-      inotifywait -e modify "${corenamefile}". | read_temperature # show temperature while waiting for the core change event 
+      inotifywait -e modify "${corenamefile}". | show_temperature # show temperature while waiting for the core change event 
     else
       inotifywait -e modify "${corenamefile}"   
     fi

--- a/i2c2oled.sh
+++ b/i2c2oled.sh
@@ -191,9 +191,9 @@ while true; do								# main loop
     fi  												# end if core check
     
     if [ "${SHOW_TEMP}" = "yes" ]; then
-      inotifywait -e modify "${corenamefile}". | show_temperature # show temperature while waiting for the core change event 
+      inotifywait -qq -e modify "${corenamefile}". | show_temperature # show temperature while waiting for the core change event 
     else
-      inotifywait -e modify "${corenamefile}"   
+      inotifywait -qq -e modify "${corenamefile}"   
     fi
     
     #inotifywait -qq -e modify "${corenamefile}"					# wait here for next change of corename -q for quite

--- a/i2c2oled.sh
+++ b/i2c2oled.sh
@@ -185,7 +185,15 @@ while true; do								# main loop
       display_on
       oldcore=${newcore}										# update oldcore variable
     fi  														# end if core check
-    inotifywait -qq -e modify "${corenamefile}"					# wait here for next change of corename -q for quite
+    current_corenamefile=${corenamefile} #store the current corename
+    while [ ${current_corenamefile} = ${corenamefile} ] #loops until change of corename occures 
+    do
+      if [ "${SHOW_TEMP}" = "yes" ]; then #show temperature 
+        read_temperature 
+      fi
+      sleep 1
+    done
+    #inotifywait -qq -e modify "${corenamefile}"					# wait here for next change of corename -q for quite
     #inotifywait -e modify -t 5 "${corenamefile}"				# wait here for next change of corename
 	#echo "5 secs Timeout"
   else  												# CORENAME file not found

--- a/i2c2oled.sh
+++ b/i2c2oled.sh
@@ -145,6 +145,10 @@ showtext "by Sorgelig"			# Some Text for the Display
 
 sleep ${SLIDETIME}			# Wait a moment
 
+if [ "${SHOW_TEMP}" = "yes" ]; then #initialize temperature sensor to default 
+        init_temperature_default_config 
+fi
+
 # reset_cursor
 
 while true; do								# main loop


### PR DESCRIPTION
This pull request is to add the capability of showing the temperature in centigrade on the OLED
This requires the installation of the AD7414 I2C temperature sensor on the RTC 1.3 board
By default the temperature in not shown to make it compatible and issue free for the unsupported hardware
In order to enable the temperature show the SHOW_TEMP variable in the i2c2oled-system.ini should be set to "yes" (default is "no") 